### PR TITLE
Removing CSS CDATA

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,10 +13,8 @@
     <link rel="help" title="Finding your way at W3C" href="https://www.w3.org/2002/03/new-to-w3c">
     <link rel="glossary" title="Index of W3C terms" href="https://www.w3.org/Help/siteindex">
     <style type="text/css">
-/*<![CDATA[*/
-#Logo { text-align:left;}
-/*]]>*/
-</style>
+    #Logo { text-align:left;}
+    </style>
   </head>
   <body>
     <div id="header">


### PR DESCRIPTION
This was useful for xhtml/xml and all the X stuff, you can do without it now and save a few bytes.